### PR TITLE
Fix layouts of lists and content

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -5,7 +5,7 @@
   {{ if ne .Params.showpagemeta false }}
   <div class="col-md-12">
     <h6 class="text-left meta">
-      PUBLISHED ON {{ .Date.Format .Site.Params.dateFormat | upper }} 
+      PUBLISHED ON {{ .Date.Format ".Site.Params.dateFormat" | upper }} 
       {{ $total := len .Params.categories }}
       {{ if gt $total 0 }}
       — 

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -4,7 +4,7 @@
     <li class="list-entry">
       <a class="list-entry-link" href="{{ .Permalink }}">{{ .Title }}</a>
       <p class="meta">
-        {{ .Date.Format .Site.Params.dateFormat | upper }} 
+        {{ .Date.Format ".Site.Params.dateFormat" | upper }} 
         <span class="category">
         {{ $total := len .Params.categories }}
         {{ if gt $total 0 }}


### PR DESCRIPTION
Hugo v0.17 was giving errors like this:
`ERROR: 2016/11/05 20:32:30 template.go:132: template: theme/partials/content.html:8:40: executing "theme/partials/content.html" at <.Site.Params.dateFor...>: invalid value; expected string in theme/partials/content.html`

Now there are no errors and hugo-goa-demo works properly after this commit. Also, it seems to be solution for #4.