### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
 
 {{ .Hugo.Generator }}
 
-{{ if .RSSlink }}
+{{ if .RSSLink }}
   <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
   <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.