### PR TITLE
Don't show "PUBLISHED ON" for content without dates

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -5,7 +5,7 @@
   {{ if ne .Params.showpagemeta false }}
   <div class="col-md-12">
     <h6 class="text-left meta">
-      PUBLISHED ON {{ .Date.Format .Site.Params.dateformat | upper }}
+       {{ if not .Date.IsZero }} PUBLISHED ON {{ .Date.Format .Site.Params.dateformat | upper }} {{end}}
       {{ if isset .Params "categories" }}
       {{ $total := len .Params.categories }}
       {{ if gt $total 0 }}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -4,7 +4,7 @@
     <li class="list-entry">
       <a class="list-entry-link" href="{{ .Permalink }}">{{ .Title }}</a>
       <p class="meta">
-        {{ .Date.Format .Site.Params.dateformat | upper }}
+        {{ if not .Date.IsZero }} {{ .Date.Format .Site.Params.dateformat | upper }} {{end}}
         <span class="category">
         {{ if isset .Params "categories" }}
         {{ $total := len .Params.categories }}


### PR DESCRIPTION
Otherwise posts without a `date` attribute in their front matter will
use a zero `time.Time`.
This results in the post showing `PUBLISHED ON JAN 1, 0001`