### PR TITLE
Turn off word wrapping for code

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -255,3 +255,8 @@ header.title
         margin-top: 30px;
     }
 }
+pre > code {
+    white-space: pre;
+    word-wrap: initial;
+    word-break: initial;
+}


### PR DESCRIPTION
Using Highlight.js, when I use fenced code blocks, the text wraps which doesn't look very nice.

This is a bit of a brute force fix for the issue. There might be a better way of doing it, but this
works for me for now.