### PR TITLE
Update rss link included in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,10 +16,9 @@
 
 {{ .Hugo.Generator }}
 
-{{ if .RSSLink }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-{{ end }}
+{{ range .AlternativeOutputFormats -}}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
 
 {{ if .Site.Params.extra.highlightjs }}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/{{ .Site.Params.extra.highlightjsstyle | default "default" }}.min.css">


### PR DESCRIPTION
Rss link generation in hugo documentation is wrong according to this
issue. Replace it with the correct links.

Issue: gohugoio/hugoDocs#369