### PR TITLE
Social Links: More supported sites added

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,18 +105,42 @@ These settings are included in the site's meta section.
 
 These settings to display your social accounts.
 
-- `github`: Your github username.
-- `instagram`: Your instagram username.
-- `xing`: Your xing username.
-- `linkedin`: Your linkedin username.
-- `twitter`: Your twitter username.
-- `facebook`: Your facebook username.
-- `google`: Your google username.
-- `medium`: Your medium username.
-- `devto`: Your dev.to username.
-- `stackoverflow`: Your stackoverflow username.
-- `angellist`: Your angellist username.
-- `email`: Your email.
+- `github`: Your [Github](https://github.com) username.
+- `instagram`: Your [Instagram](https://www.instagram.com) username.
+- `xing`: Your [Xing](https://www.xing.com) username.
+- `linkedin`: Your [Linkedin](https://www.linkedin.com) username.
+- `twitter`: Your [Twitter](https://twitter.com) username.
+- `facebook`: Your [Facebook](https://www.facebook.com) username.
+- `google`: Your [Google](https://www.google.com) username.
+- `medium`: Your [Medium](https://medium.com) username.
+- `devto`: Your [dev.to](https://dev.to) username.
+- `stackoverflow`: Your [StackOverflow](https://stackoverflow.com) username.
+- `angellist`: Your [AngelList](https://angel.co) username.
+- `lastfm`: Your [Last.fm](https://www.last.fm) username.
+- `goodreads`: Your [Goodreads](https://www.goodreads.com) username.
+- `gitlab`: Your [Gitlab](https://gitlab.com) username.
+- `bitbucket`: Your [BitBucket](https://bitbucket.org) username.
+- `fivehundredpx`: Your [500px](https://500px.com) username.
+- `flickr`: Your [Flickr](https://flickr.com) username.
+- `foursquare`: Your [Foursquare](https://foursquare.com) username.
+- `hackernews`: Your [Y Combinator Hackernews](https://news.ycombinator.com) username.
+- `kickstarter`: Your [Kickstarter](https://kickstarter.com) username.
+- `patreon`: Your [Patreon](https://patreon.com) username.
+- `pintrest`: Your [Pintrest](https://pintrest.com) username.
+- `steam`: Your [Steam](https://steamcommunity.com) username.
+- `reddit`: Your [Reddit](https://www.reddit.com) username.
+- `snapchat`: Your [Snapchat](https://snapchat.com) username.
+- `keybase`: Your [Keybase](https://keybase.io) username.
+- `twitch`: Your [Twitch](https://twitch.tv) username.
+- `youtube`: Your [YouTube](https://youtube.com) username.
+- `soundcloud`: Your [Soundcloud](https://soundcloud.com) username.
+- `tumblr`: Your [Tumblr](https://tumblr.com) username.
+- `skype`: Your [skype](https://skype.com) username.
+- `telegram`: Your [Telegram](https://telegram.com) username.
+- `whatsapp`: Your phone number.* Follow the steps [here](https://faq.whatsapp.com/en/26000030/).
+- `email`: Your email.*
+
+* `WARNING`: It is recommended to keep your private data (phone number/ email) private. Especially if you don't use them for business. Adding it to your public will expose your data to the public. This is irreversabile.
 
 ### Extras `[params.extra]`
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,6 @@
 ## Basic Configuration
 
-baseurl = "https://shenoybr.github.io/hugo-goa-demo/" 
+baseurl = "https://shenoybr.github.io/hugo-goa-demo/"
 builddrafts = false
 canonifyurls = false
 languageCode = "en-US"
@@ -42,11 +42,33 @@ twitter = "<username>"
 facebook = "<username>"
 google = "<username>"
 stackoverflow = "<username>"
+lastfm = "<username>"
+goodreads = "<username>"
+gitlab = "<username>"
+bitbucket = "<username>"
+fivehundredpx = "<username>"
+flickr = "<username>"
+foursquare = "<username>"
+hackernews = "<username>"
+kickstarter = "<username>"
+patreon = "<username>"
+pintrest = "<username>"
+steam = "<username>"
+reddit = "<username>"
+snapchat = "<username>"
+youtube = "<username>"
+keybase = "<username>"
+twitch = "<username>"
+soundcloud = "<username>"
+tumblr = "<username>"
+skype = "<username>"
+telegram = "<username>"
+whatsapp = "<username>"
 email = "you@example.com"
 
 ## Extras
 [params.extra]
-copyright = "© 2016. Erlich Bachman. [Some Rights Reserved](http://creativecommons.org/licenses/by/3.0/)." 
+copyright = "© 2016. Erlich Bachman. [Some Rights Reserved](http://creativecommons.org/licenses/by/3.0/)."
 poweredby = true
 highlightjs = true
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -26,7 +26,7 @@
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400|Roboto+Slab:400,700|Roboto:300,300i,400,400i,500,500i,700,700i">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
++<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css">
 <link rel="stylesheet" href="{{ "css/main.css" | absURL }}">
 
 <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,107 +1,107 @@
 <section id="social-pane" class="row text-center social">
   {{ with .Site.Params.social.twitter }}
-  <a href="https://twitter.com/{{.}}" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+  <a href="https://twitter.com/{{.}}" aria-label="Twitter" target="_blank"><i class="fab fa-twitter" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.google }}
-  <a href="https://plus.google.com/{{.}}/about" aria-label="Google Plus"><i class="fab fa-google-plus" aria-hidden="true"></i></a>
+  <a href="https://plus.google.com/{{.}}/about" aria-label="Google Plus" target="_blank"><i class="fab fa-google-plus" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.goodreads }}
-  <a href="https://www.goodreads.com/user/show/{{.}}" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
+  <a href="https://www.goodreads.com/user/show/{{.}}" aria-label="Goodreads" target="_blank"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.lastfm }}
-  <a href="https://www.last.fm/user/{{.}}/" aria-label="Last.fm"><i class="fab fa-lastfm" aria-hidden="true"></i></a>
+  <a href="https://www.last.fm/user/{{.}}/" aria-label="Last.fm" target="_blank"><i class="fab fa-lastfm" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.facebook }}
-  <a href="https://facebook.com/{{.}}" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
+  <a href="https://facebook.com/{{.}}" aria-label="Facebook" target="_blank"><i class="fab fa-facebook" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.github }}
-  <a href="https://github.com/{{.}}" aria-label="Github"><i class="fab fa-github" aria-hidden="true"></i></a>
+  <a href="https://github.com/{{.}}" aria-label="Github" target="_blank"><i class="fab fa-github" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.instagram }}
-  <a href="https://instagram.com/{{.}}" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+  <a href="https://instagram.com/{{.}}" aria-label="Instagram" target="_blank"><i class="fab fa-instagram" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.linkedin }}
-  <a href="https://linkedin.com/in/{{.}}" aria-label="LinkedIn"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+  <a href="https://linkedin.com/in/{{.}}" aria-label="LinkedIn" target="_blank"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.stackoverflow }}
-  <a href="https://stackoverflow.com/users/{{.}}" aria-label="StackOverflow"><i class="fab fa-stack-overflow" aria-hidden="true"></i></a>
+  <a href="https://stackoverflow.com/users/{{.}}" aria-label="StackOverflow" target="_blank"><i class="fab fa-stack-overflow" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.medium}}
-  <a href="https://medium.com/{{.}}" aria-label="Medium"><i class="fab fa-medium" aria-hidden="true"></i></a>
+  <a href="https://medium.com/{{.}}" aria-label="Medium" target="_blank"><i class="fab fa-medium" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.devto}}
-  <a href="https://dev.to/{{.}}" aria-label="Dev.to"><i class="fas fa-terminal" aria-hidden="true"></i></a>
+  <a href="https://dev.to/{{.}}" aria-label="Dev.to" target="_blank"><i class="fas fa-terminal" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.angellist}}
-  <a href="https://angel.co/{{.}}" aria-label="AngelList"><i class="fab fa-angellist" aria-hidden="true"></i></a>
+  <a href="https://angel.co/{{.}}" aria-label="AngelList" target="_blank"><i class="fab fa-angellist" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.xing }}
-  <a href="https://www.xing.com/profile/{{.}}" aria-label="Xing"><i class="fab fa-xing" aria-hidden="true"></i></a>
+  <a href="https://www.xing.com/profile/{{.}}" aria-label="Xing" target="_blank"><i class="fab fa-xing" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.gitlab}}
-  <a href="https://gitlab.com/{{.}}" aria-label="Gitlab"><i class="fab fa-gitlab" aria-hidden="true"></i></a>
+  <a href="https://gitlab.com/{{.}}" aria-label="Gitlab" target="_blank"><i class="fab fa-gitlab" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.bitbucket}}
-  <a href="https://bitbucket.org/{{.}}" aria-label="Bitbucket"><i class="fab fa-bitbucket" aria-hidden="true"></i></a>
+  <a href="https://bitbucket.org/{{.}}" aria-label="Bitbucket" target="_blank"><i class="fab fa-bitbucket" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.fivehundredpx}}
-  <a href="https://500px.com/{{.}}" aria-label="500px"><i class="fab fa-500px" aria-hidden="true"></i></a>
+  <a href="https://500px.com/{{.}}" aria-label="500px" target="_blank"><i class="fab fa-500px" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.flickr}}
-  <a href="https://flickr.com/photos/{{.}}" aria-label="Flickr"><i class="fab fa-flickr" aria-hidden="true"></i></a>
+  <a href="https://flickr.com/photos/{{.}}" aria-label="Flickr" target="_blank"><i class="fab fa-flickr" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.foursquare}}
-  <a href="https://foursquare.com/{{.}}" aria-label="Foursquare"><i class="fab fa-foursquare" aria-hidden="true"></i></a>
+  <a href="https://foursquare.com/{{.}}" aria-label="Foursquare" target="_blank"><i class="fab fa-foursquare" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.hackernews}}
-  <a href="https://news.ycombinator.com/user?id={{.}}" aria-label="Y Combinator Hackernews"><i class="fab fa-hacker-news" aria-hidden="true"></i></a>
+  <a href="https://news.ycombinator.com/user?id={{.}}" aria-label="Y Combinator Hackernews" target="_blank"><i class="fab fa-hacker-news" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.kickstarter}}
-  <a href="https://kickstarter.com/profile/{{.}}" aria-label="Kickstarter"><i class="fab fa-kickstarter" aria-hidden="true"></i></a>
+  <a href="https://kickstarter.com/profile/{{.}}" aria-label="Kickstarter" target="_blank"><i class="fab fa-kickstarter" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.patreon}}
-  <a href="https://patreon.com/{{.}}" aria-label="Patreon"><i class="fab fa-patreon" aria-hidden="true"></i></a>
+  <a href="https://patreon.com/{{.}}" aria-label="Patreon" target="_blank"><i class="fab fa-patreon" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.pintrest}}
-  <a href="https://pintrest.com/{{.}}" aria-label="Pintrest"><i class="fab fa-pintrest" aria-hidden="true"></i></a>
+  <a href="https://pintrest.com/{{.}}" aria-label="Pintrest" target="_blank"><i class="fab fa-pintrest" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.steam}}
-  <a href="https://steamcommunity.com/id/{{.}}" aria-label="Steam"><i class="fab fa-steam" aria-hidden="true"></i></a>
+  <a href="https://steamcommunity.com/id/{{.}}" aria-label="Steam" target="_blank"><i class="fab fa-steam" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.reddit}}
-  <a href="https://www.reddit.com/user/{{.}}" aria-label="Reddit"><i class="fab fa-reddit" aria-hidden="true"></i></a>
+  <a href="https://www.reddit.com/user/{{.}}" aria-label="Reddit" target="_blank"><i class="fab fa-reddit" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.snapchat}}
-  <a href="https://snapchat.com/add/{{.}}" aria-label="Snapchat"><i class="fab fa-snapchat" aria-hidden="true"></i></a>
+  <a href="https://snapchat.com/add/{{.}}" aria-label="Snapchat" target="_blank"><i class="fab fa-snapchat" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.youtube}}
-  <a href="https://youtube.com/user/{{.}}" aria-label="Youtube"><i class="fab fa-youtube" aria-hidden="true"></i></a>
+  <a href="https://youtube.com/user/{{.}}" aria-label="Youtube" target="_blank"><i class="fab fa-youtube" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.keybase}}
-  <a href="https://keybase.io/{{.}}" aria-label="Keybase"><i class="fab fa-keybase" aria-hidden="true"></i></a>
+  <a href="https://keybase.io/{{.}}" aria-label="Keybase" target="_blank"><i class="fab fa-keybase" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.twitch}}
-  <a href="https://www.twitch.tv/{{.}}" aria-label="Twitch"><i class="fab fa-twitch" aria-hidden="true"></i></a>
+  <a href="https://www.twitch.tv/{{.}}" aria-label="Twitch" target="_blank"><i class="fab fa-twitch" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.soundcloud}}
-  <a href="https://soundcloud.com/{{.}}" aria-label="Soundcloud"><i class="fab fa-soundcloud" aria-hidden="true"></i></a>
+  <a href="https://soundcloud.com/{{.}}" aria-label="Soundcloud" target="_blank"><i class="fab fa-soundcloud" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.tumblr}}
-  <a href="https://{{.}}.tumblr.com" aria-label="Tumblr"><i class="fab fa-tumblr" aria-hidden="true"></i></a>
+  <a href="https://{{.}}.tumblr.com" aria-label="Tumblr" target="_blank"><i class="fab fa-tumblr" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.skype}}
-  <a href="skype:{{.}}" aria-label="Skype"><i class="fab fa-skype" aria-hidden="true"></i></a>
+  <a href="skype:{{.}}" aria-label="Skype" target="_blank"><i class="fab fa-skype" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.telegram}}
-  <a href="https://t.me/{{.}}" aria-label="Telegram"><i class="fab fa-telegram" aria-hidden="true"></i></a>
+  <a href="https://t.me/{{.}}" aria-label="Telegram" target="_blank"><i class="fab fa-telegram" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.whatsapp}}
-  <a href="https://wa.me/{{.}}" aria-label="Whatsapp"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
+  <a href="https://wa.me/{{.}}" aria-label="Whatsapp" target="_blank"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.email }}
-  <a href="mailto:{{.}}" aria-label="Email"><i class="fas fa-envelope-o" aria-hidden="true"></i></a>
+  <a href="mailto:{{.}}" aria-label="Email" target="_blank"><i class="fas fa-envelope-o" aria-hidden="true"></i></a>
   {{ end }}
   {{ if and ( .Site.Params.extra.rss ) ( .RSSLink ) }}
-  <a href="{{ .RSSLink }}" aria-label="RSS"><i class="fas fa-rss" aria-hidden="true"></i></a>
+  <a href="{{ .RSSLink }}" aria-label="RSS" target="_blank"><i class="fas fa-rss" aria-hidden="true"></i></a>
   {{ end }}
 </section>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,41 +1,41 @@
 <section id="social-pane" class="row text-center social">
   {{ with .Site.Params.social.twitter }}
-  <a href="https://twitter.com/{{.}}"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+  <a href="https://twitter.com/{{.}}" aria-label="Twitter"><i class="fab fa-twitter" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.google }}
-  <a href="https://plus.google.com/{{.}}/about"><i class="fa fa-google-plus-official" aria-hidden="true"></i></a>
+  <a href="https://plus.google.com/{{.}}/about" aria-label="Google Plus"><i class="fab fa-google-plus" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.facebook }}
-  <a href="https://facebook.com/{{.}}"><i class="fa fa-facebook-official" aria-hidden="true"></i></a>
+  <a href="https://facebook.com/{{.}}" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.github }}
-  <a href="https://github.com/{{.}}"><i class="fa fa-github" aria-hidden="true"></i></a>
+  <a href="https://github.com/{{.}}" aria-label="Github"><i class="fab fa-github" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.instagram }}
-  <a href="https://instagram.com/{{.}}"><i class="fa fa-instagram" aria-hidden="true"></i></a>
+  <a href="https://instagram.com/{{.}}" aria-label="Instagram"><i class="fab fa-instagram" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.linkedin }}
-  <a href="https://linkedin.com/in/{{.}}"><i class="fa fa-linkedin" aria-hidden="true"></i></a>
+  <a href="https://linkedin.com/in/{{.}}" aria-label="LinkedIn"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.stackoverflow }}
-  <a href="https://stackoverflow.com/users/{{.}}"><i class="fa fa-stack-overflow" aria-hidden="true"></i></a>
+  <a href="https://stackoverflow.com/users/{{.}}" aria-label="StackOverflow"><i class="fab fa-stack-overflow" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.medium}}
-  <a href="https://medium.com/{{.}}"><i class="fa fa-medium" aria-hidden="true"></i></a>
+  <a href="https://medium.com/{{.}}" aria-label="Medium"><i class="fab fa-medium" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.devto}}
-  <a href="https://dev.to/{{.}}"><i class="fa fa-terminal" aria-hidden="true"></i></a>
+  <a href="https://dev.to/{{.}}" aria-label="Dev.to"><i class="fas fa-terminal" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.angellist}}
-  <a href="https://angel.co/{{.}}"><i class="fa fa-angellist" aria-hidden="true"></i></a>
+  <a href="https://angel.co/{{.}}" aria-label="AngelList"><i class="fab fa-angellist" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.email }}
-  <a href="mailto:{{.}}"><i class="fa fa-envelope-o" aria-hidden="true"></i></a>
+  <a href="mailto:{{.}}" aria-label="Email"><i class="fas fa-envelope-o" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.xing }}
-  <a href="https://www.xing.com/profile/{{.}}"><i class="fa fa-xing" aria-hidden="true"></i></a>
+  <a href="https://www.xing.com/profile/{{.}}" aria-label="Xing"><i class="fab fa-xing" aria-hidden="true"></i></a>
   {{ end }}
   {{ if and ( .Site.Params.extra.rss ) ( .RSSLink ) }}
-  <a href="{{ .RSSLink }}"><i class="fa fa-rss" aria-hidden="true"></i></a>
+  <a href="{{ .RSSLink }}" aria-label="RSS"><i class="fas fa-rss" aria-hidden="true"></i></a>
   {{ end }}
 </section>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -5,6 +5,12 @@
   {{ with .Site.Params.social.google }}
   <a href="https://plus.google.com/{{.}}/about" aria-label="Google Plus"><i class="fab fa-google-plus" aria-hidden="true"></i></a>
   {{ end }}
+  {{ with .Site.Params.social.goodreads }}
+  <a href="https://www.goodreads.com/user/show/{{.}}" aria-label="Goodreads"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.lastfm }}
+  <a href="https://www.last.fm/user/{{.}}/" aria-label="Last.fm"><i class="fab fa-lastfm" aria-hidden="true"></i></a>
+  {{ end }}
   {{ with .Site.Params.social.facebook }}
   <a href="https://facebook.com/{{.}}" aria-label="Facebook"><i class="fab fa-facebook" aria-hidden="true"></i></a>
   {{ end }}
@@ -29,11 +35,71 @@
   {{ with .Site.Params.social.angellist}}
   <a href="https://angel.co/{{.}}" aria-label="AngelList"><i class="fab fa-angellist" aria-hidden="true"></i></a>
   {{ end }}
-  {{ with .Site.Params.social.email }}
-  <a href="mailto:{{.}}" aria-label="Email"><i class="fas fa-envelope-o" aria-hidden="true"></i></a>
-  {{ end }}
   {{ with .Site.Params.social.xing }}
   <a href="https://www.xing.com/profile/{{.}}" aria-label="Xing"><i class="fab fa-xing" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.gitlab}}
+  <a href="https://gitlab.com/{{.}}" aria-label="Gitlab"><i class="fab fa-gitlab" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.bitbucket}}
+  <a href="https://bitbucket.org/{{.}}" aria-label="Bitbucket"><i class="fab fa-bitbucket" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.fivehundredpx}}
+  <a href="https://500px.com/{{.}}" aria-label="500px"><i class="fab fa-500px" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.flickr}}
+  <a href="https://flickr.com/photos/{{.}}" aria-label="Flickr"><i class="fab fa-flickr" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.foursquare}}
+  <a href="https://foursquare.com/{{.}}" aria-label="Foursquare"><i class="fab fa-foursquare" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.hackernews}}
+  <a href="https://news.ycombinator.com/user?id={{.}}" aria-label="Y Combinator Hackernews"><i class="fab fa-hacker-news" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.kickstarter}}
+  <a href="https://kickstarter.com/profile/{{.}}" aria-label="Kickstarter"><i class="fab fa-kickstarter" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.patreon}}
+  <a href="https://patreon.com/{{.}}" aria-label="Patreon"><i class="fab fa-patreon" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.pintrest}}
+  <a href="https://pintrest.com/{{.}}" aria-label="Pintrest"><i class="fab fa-pintrest" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.steam}}
+  <a href="https://steamcommunity.com/id/{{.}}" aria-label="Steam"><i class="fab fa-steam" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.reddit}}
+  <a href="https://www.reddit.com/user/{{.}}" aria-label="Reddit"><i class="fab fa-reddit" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.snapchat}}
+  <a href="https://snapchat.com/add/{{.}}" aria-label="Snapchat"><i class="fab fa-snapchat" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.youtube}}
+  <a href="https://youtube.com/user/{{.}}" aria-label="Youtube"><i class="fab fa-youtube" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.keybase}}
+  <a href="https://keybase.io/{{.}}" aria-label="Keybase"><i class="fab fa-keybase" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.twitch}}
+  <a href="https://www.twitch.tv/{{.}}" aria-label="Twitch"><i class="fab fa-twitch" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.soundcloud}}
+  <a href="https://soundcloud.com/{{.}}" aria-label="Soundcloud"><i class="fab fa-soundcloud" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.tumblr}}
+  <a href="https://{{.}}.tumblr.com" aria-label="Tumblr"><i class="fab fa-tumblr" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.skype}}
+  <a href="skype:{{.}}" aria-label="Skype"><i class="fab fa-skype" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.telegram}}
+  <a href="https://t.me/{{.}}" aria-label="Telegram"><i class="fab fa-telegram" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.whatsapp}}
+  <a href="https://wa.me/{{.}}" aria-label="Whatsapp"><i class="fab fa-whatsapp" aria-hidden="true"></i></a>
+  {{ end }}
+  {{ with .Site.Params.social.email }}
+  <a href="mailto:{{.}}" aria-label="Email"><i class="fas fa-envelope-o" aria-hidden="true"></i></a>
   {{ end }}
   {{ if and ( .Site.Params.extra.rss ) ( .RSSLink ) }}
   <a href="{{ .RSSLink }}" aria-label="RSS"><i class="fas fa-rss" aria-hidden="true"></i></a>


### PR DESCRIPTION
Builds on: #45 (requirement to get all the icons)

(This commit also forces links on sites to open in a new tab)

Adds support for:
- Last.fm
- Goodreads
- Gitlab
- Bitbucket
- 500px (spelled as fivehundredpx in the config)
- Flickr
- Foursquare
- Hackernews
- Kickstarter
- Patreon
- Pintrest
- Steam
- Reddit
- Snapchat
- Youtube
- Keybase
- Twitch
- Soundcloud
- Tumblr
- Skype
- Telegram
- WhatsApp