### PR TITLE
Revert "Add a Gitlab Social icon"

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -17,9 +17,6 @@
   {{ with .Site.Params.social.github }}
   <a href="https://github.com/{{.}}" aria-label="Github" target="_blank"><i class="fab fa-github" aria-hidden="true"></i></a>
   {{ end }}
-  {{ with .Site.Params.social.gitlab }}
-  <a href="https://gitlab.com/{{.}}"><i class="fa fa-gitlab" aria-hidden="true"></i></a>
-  {{ end }}
   {{ with .Site.Params.social.instagram }}
   <a href="https://instagram.com/{{.}}" aria-label="Instagram" target="_blank"><i class="fab fa-instagram" aria-hidden="true"></i></a>
   {{ end }}


### PR DESCRIPTION
Reverts shenoybr/hugo-goa#50

Apologies for reverting this, but the order of merge caused a duplicate of 'Gitlab' with #46 