### PR TITLE
Fix Goodreads link

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -9,7 +9,7 @@
   <a href="https://scholar.google.com/citations?user={{.}}" aria-label="Google Scholar" target="_blank"><i class="fas fa-graduation-cap" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.goodreads }}
-  <a href="https://www.goodreads.com/user/show/{{.}}" aria-label="Goodreads" target="_blank"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
+  <a href="https://www.goodreads.com/{{.}}" aria-label="Goodreads" target="_blank"><i class="fab fa-goodreads" aria-hidden="true"></i></a>
   {{ end }}
   {{ with .Site.Params.social.lastfm }}
   <a href="https://www.last.fm/user/{{.}}/" aria-label="Last.fm" target="_blank"><i class="fab fa-lastfm" aria-hidden="true"></i></a>


### PR DESCRIPTION
Hi @shenoybr,

Goodreads changed the url format of the users page, it is now https://goodreads.com/<username>