### PR TITLE
Add relative linking to menu item template and remove base url from header template

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,8 +10,6 @@
 {{ with .Site.Params.meta.description }}<meta name="description" content="{{ . }}">{{ end }}
 {{ with .Site.Params.meta.keywords }}<meta name="keywords" content="{{.}}">{{ end }}
 
-<base href="{{ .Site.BaseURL }}">
-
 <title>
 {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }} {{ if eq $url "" }} {{ .Site.Title }} {{ else }} {{ .Site.Title }} - {{ .Title }} {{ end }}
 </title>

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -2,7 +2,7 @@
   <ul >
     {{ range .Data.Pages.ByPublishDate.Reverse }}
     <li class="list-entry">
-      <a class="list-entry-link" href="{{ .Permalink }}">{{ .Title }}</a>
+      <a class="list-entry-link" href="{{ .RelPermalink }}">{{ .Title }}</a>
       <p class="meta">
         {{ if not .Date.IsZero }} {{ .Date.Format .Site.Params.dateformat | upper }} {{end}}
         <span class="category">


### PR DESCRIPTION
This PR fixes a relative URL issue that causes the following behavior:

- When deploying to a test location, the base URL of the test location is overwritten by the `baseURL` that is loaded into the `<base>` tag. This is solved by removing the line of HTML that generates that tag in the `header.html` template.
- When deploying in any environment, footnotes do not work. The generated footnote links are relative and so are appended to the base URL and the user is redirected to e.g. `https://mybaseurl.com/#fn:1`. Removing the base URL fixes this issue as well.
- When deploying to a test location, after clicking a menu item on the main page you are brought to a list of posts. Clicking on a post redirects the user to e.g. `https://www.mybaseurl.com/menuitem/post` instead of `test-location/menuitem/post`. This is fixed by changing the line in `li.html` to have `.RelPermalink` instead of `.Permalink`.