### PR TITLE
Upgraded Bootstrap from 3.3.7 to 4.5.2

### DIFF
--- a/layouts/partials/avatar.html
+++ b/layouts/partials/avatar.html
@@ -1,4 +1,4 @@
-<header class="row text-center header">
-  {{ with .Site.Params.authorimage }} <img src="/img/{{ . }}" alt="Author Image" class="img-circle text-center headshot"> {{ end }}
+<header class="text-center header">
+  {{ with .Site.Params.authorimage }} <img src="/img/{{ . }}" alt="Author Image" class="rounded-circle text-center headshot"> {{ end }}
   <h1 class="author">{{ .Site.Params.author }}</h1>
 </header>

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,7 +1,7 @@
-<header class="row text-left title">
+<header class="text-left title">
   <h1 class="title">{{ .Title }}</h1>
 </header>
-<section id="category-pane" class="row meta">
+<section id="category-pane" class="meta">
   {{ if ne .Params.showpagemeta false }}
   <div class="col-md-12">
     <h6 class="text-left meta">
@@ -20,7 +20,7 @@
   </div>
   {{ end }}
 </section>
-<section id="content-pane" class="row">
+<section id="content-pane" class="">
   <div class="col-md-12 text-justify content">
     {{ if and ( ne .Params.toc false) (gt .WordCount 300 ) }}
     {{ .TableOfContents }}
@@ -28,7 +28,7 @@
     {{ .Content }}
   </div>
 </section>
-<section id="tag-pane" class="row meta">
+<section id="tag-pane" class="meta">
   {{ if ne .Params.showpagemeta false }}
   <div class="col-md-12">
     <h6 class="text-right meta">

--- a/layouts/partials/error.html
+++ b/layouts/partials/error.html
@@ -1,4 +1,4 @@
-<section id="error-pane" class="row text-center error">
+<section id="error-pane" class="text-center error">
   <h1 class="text-center">404</h1>
   <p>Sorry! That page does not exist. It may have been removed or moved to a new section on the site. Click <a href="/">here</a> go back to the home page.</p>
 </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -25,7 +25,7 @@
 {{ end }}
 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400|Roboto+Slab:400,700|Roboto:300,300i,400,400i,500,500i,700,700i">
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
 <link rel="stylesheet" href="{{ "css/main.css" | absURL }}">
 <link rel="stylesheet" href="{{ "css/custom.css" | absURL }}">

--- a/layouts/partials/info.html
+++ b/layouts/partials/info.html
@@ -1,4 +1,4 @@
-<section id="info-pane" class="row text-center info">
+<section id="info-pane" class="text-center info">
   {{ with .Site.Params.intro }}
   <h3 class="intro">{{ . | markdownify }}</h3>
   {{ end }}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,4 +1,4 @@
-<section id="list-pane" class="row list">
+<section id="list-pane" class="list">
   <ul >
     {{ range .Data.Pages.ByPublishDate.Reverse }}
     <li class="list-entry">

--- a/layouts/partials/main_menu.html
+++ b/layouts/partials/main_menu.html
@@ -1,4 +1,4 @@
-<section id="main-menu-pane" class="row text-center main-menu">
+<section id="main-menu-pane" class="text-center main-menu">
   {{ range sort .Site.Menus.main }}
   <h4><a class="menu-item" href="{{ .URL }}">{{ .Name | lower }}</a></h4>
   {{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,4 +1,4 @@
-<section id="menu-pane" class="row menu text-center">
+<section id="menu-pane" class="menu text-center">
   {{ if not .IsNode }}
   {{ with .PrevInSection }}
   <span><a class="menu-item" href="{{ .Permalink }}">&lt; prev | </a></span>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,4 +1,4 @@
-<section id="social-pane" class="row text-center social">
+<section id="social-pane" class="text-center social">
   {{ with .Site.Params.social.twitter }}
   <a href="https://twitter.com/{{.}}" aria-label="Twitter" target="_blank"><i class="fab fa-twitter" aria-hidden="true"></i></a>
   {{ end }}

--- a/layouts/partials/sub_footer.html
+++ b/layouts/partials/sub_footer.html
@@ -1,4 +1,4 @@
-<footer class="row text-center footer">
+<footer class="text-center footer">
   <hr />
   {{ with .Site.Params.extra }}
   <h6 class="text-center copyright">{{ .copyright | markdownify }}</h6>


### PR DESCRIPTION
This PR will Upgrade Bootstrap from 3.3.7 to the latest release (4.5.2),
I have tested every site that I know exists with the theme and everything looks good on my computer