### PR TITLE
Fixed some w3 validator and google search console errors

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,6 @@
 <html lang="{{ .Site.LanguageCode }}">
 <head>
 
-<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -24,7 +23,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/{{ .Site.Params.extra.highlightjsstyle | default "default" }}.min.css">
 {{ end }}
 
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400|Roboto+Slab:400,700|Roboto:300,300i,400,400i,500,500i,700,700i">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400&family=Roboto+Slab:400,700&family=Roboto:300,300i,400,400i,500,500i,700,700i">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
 <link rel="stylesheet" href="{{ "css/main.css" | absURL }}">

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -153,7 +153,7 @@
     {{ with .Site.Params.social.twitch}}"https://www.twitch.tv/{{.}}",{{ end }}
     {{ with .Site.Params.social.soundcloud}}"https://soundcloud.com/{{.}}",{{ end }}
     {{ with .Site.Params.social.tumblr}}"https://{{.}}.tumblr.com",{{ end }}
-    {{ with .Site.Params.social.strava}}"https://www.strava.com/athletes/{{.}}",{{ end }},
+    {{ with .Site.Params.social.strava}}"https://www.strava.com/athletes/{{.}}",{{ end }}
     "{{ .Site.Params.baseURL }}"
   ]
 }


### PR DESCRIPTION
Fixed some w3 validator and google search console errors:
- A document must not include both a `meta` element with an `http-equiv` attribute whose value is `content-type`, and a `meta` element with a `charset` attribute.
- Bad value `https://fonts.googleapis.com/css?family=Lato:300,400|Roboto+Slab:400,700|Roboto:300,300i,400,400i,500,500i,700,700i` for attribute `href` on element `link`: Illegal character in query: `|` is not allowed.
- Not all markup is eligible for rich results: two sequential commas